### PR TITLE
[POC] Add poc with IO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,20 @@ apply plugin: 'kotlin'
 
 repositories {
     mavenCentral()
+    jcenter()
 }
 
 dependencies {
+    compile 'io.arrow-kt:arrow-core:0.7.1'
+    compile 'io.arrow-kt:arrow-syntax:0.7.1'
+    compile 'io.arrow-kt:arrow-typeclasses:0.7.1'
+    compile 'io.arrow-kt:arrow-data:0.7.1'
+    compile 'io.arrow-kt:arrow-instances-core:0.7.1'
+    compile 'io.arrow-kt:arrow-instances-data:0.7.1'
+    kapt 'io.arrow-kt:arrow-annotations-processor:0.7.1'
+    compile 'io.arrow-kt:arrow-mtl:0.7.1'
+    compile 'io.arrow-kt:arrow-effects:0.7.1'
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
 

--- a/src/main/kotlin/com/fpinbo/kall/KallMe.kt
+++ b/src/main/kotlin/com/fpinbo/kall/KallMe.kt
@@ -1,0 +1,62 @@
+package com.fpinbo.kall
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import arrow.effects.IO
+import retrofit2.Callback
+
+sealed class KallMe<A> {
+
+    companion object {}
+
+    abstract fun cancel()
+
+    abstract fun clone(): KallMe<A>
+
+    //    abstract fun run(): EitherT<ForIO, Throwable, A>
+    // TODO find a proper type for computational errors (or leave this to the user, putting an E type param)
+    // TODO find a way to achieve a signature like: fun run(): IO<Either<Throwable, A>>
+    abstract fun run(): IO<Either<Throwable, retrofit2.Response<A>>>
+
+    abstract val cancelled: Boolean
+
+    abstract val executed: Boolean
+
+    internal data class RetrofitKall<A>(
+            private val retrofitCall: retrofit2.Call<A>
+    ) : KallMe<A>() {
+        override fun cancel() = retrofitCall.cancel()
+
+        override fun clone() = RetrofitKall(retrofitCall.clone())
+
+        override fun run(): IO<Either<Throwable, retrofit2.Response<A>>> {
+
+            return IO.async<Either<Throwable, retrofit2.Response<A>>> { callback ->
+                retrofitCall.enqueue(object : Callback<A> {
+
+                    override fun onResponse(call: retrofit2.Call<A>, response: retrofit2.Response<A>) {
+                        // that's weird, but it's due to the double error channel:
+                        // 1- IO errors
+                        // 2- errors due to either
+                        callback(Either.right(response.right()))
+                    }
+
+                    override fun onFailure(call: retrofit2.Call<A>, t: Throwable) {
+                        // TODO pair the error with the call
+                        callback(t.left())
+                    }
+                })
+            }
+
+        }
+
+        override val cancelled: Boolean
+            get() = retrofitCall.isCanceled
+
+        override val executed: Boolean
+            get() = retrofitCall.isExecuted
+
+    }
+
+}


### PR DESCRIPTION
This POC will show what I had in mind at first.
It's fairly incomplete, but it may give you the basic idea.

Open points:
- how to support error handling: with IO we have two choices:
  - returning an IO<Response<A>>
  - returning an IO<Either<E, Response<A>>>, 
  - right now in the scala world there's a nice debate on a related manner (not properly this scenario, but something similar)
- how to properly handle thread pools in IO vs Retrofit
 
TBD
